### PR TITLE
Capture & exit using pytest return code in test_imagecodecs.py

### DIFF
--- a/tests/test_imagecodecs.py
+++ b/tests/test_imagecodecs.py
@@ -2364,4 +2364,5 @@ if __name__ == '__main__':
     warnings.filterwarnings('ignore', category=ImportWarning)  # noqa
     argv = sys.argv
     argv.append('-vv')
-    pytest.main(argv)
+    retcode = pytest.main(argv)
+    sys.exit(retcode)


### PR DESCRIPTION
Done so `python tests/test_imagecodecs.py` exits with a failure code when tests fail (as `pytest tests/test_imagecodecs.py` does); among other things, this ensures that CI/CD systems that run `python tests/test_imagecodecs.py` do not mistakenly detect tests as passing when they actually did not.