### PR TITLE
Enable Jpeg XL for MSYS2 builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -511,7 +511,6 @@ def customize_build_mingw(EXTENSIONS, OPTIONS):
     del EXTENSIONS['apng']
     del EXTENSIONS['brunsli']
     del EXTENSIONS['jpeg12']
-    del EXTENSIONS['jpegxl']
     del EXTENSIONS['mozjpeg']  # Win32 only
     del EXTENSIONS['zfp']
     del EXTENSIONS['zlibng']


### PR DESCRIPTION
Package will shortly be available in the repos: https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-libjxl