### PR TITLE
Properly check dtype of numpy arrays

### DIFF
--- a/imagecodecs/_cms.pyx
+++ b/imagecodecs/_cms.pyx
@@ -369,13 +369,13 @@ def cms_profile(
         elif transferfunction is not None:
             tf = numpy.ascontiguousarray(transferfunction)
             if tf.ndim == 1:
-                if tf.char == 'H':
+                if tf.dtype.char == 'H':
                     pTransferFunction = cmsBuildTabulatedToneCurve16(
                         <cmsContext> NULL,
                         <cmsUInt32Number> tf.shape[0],
                         <const cmsUInt16Number*> &tf.data[0]
                     )
-                elif tf.char == 'f':
+                elif tf.dtype.char == 'f':
                     pTransferFunction = cmsBuildTabulatedToneCurveFloat(
                         <cmsContext> NULL,
                         <cmsUInt32Number> tf.shape[0],
@@ -388,14 +388,14 @@ def cms_profile(
             elif tf.ndim == 2:
                 if tf.shape[0] != 3:
                     raise ValueError('invalid transferfunction shape')
-                if tf.char == 'H':
+                if tf.dtype.char == 'H':
                     for i in range(3):
                         ppTransferFunction[i] = cmsBuildTabulatedToneCurve16(
                             <cmsContext> NULL,
                             <cmsUInt32Number> tf.shape[1],
                             <const cmsUInt16Number*> &tf.data[i]
                         )
-                elif tf.char == 'f':
+                elif tf.dtype.char == 'f':
                     for i in range(3):
                         ppTransferFunction[i] = (
                             cmsBuildTabulatedToneCurveFloat(


### PR DESCRIPTION
.char is not a valid attribute of an array, but is a valid attribute of array.dtype

This causes errors when trying to use transferfunction.  (will try to reproduce tomorrow, I've move to using gamma to allow unbounded profiles - see https://ninedegreesbelow.com/photography/lcms2-unbounded-mode.html - a preliminary implementation of gamma support is in the next pull request