### PR TITLE
Improvements and fixes to building ICC profiles with transferfunction tables

### DIFF
--- a/imagecodecs/_cms.pyx
+++ b/imagecodecs/_cms.pyx
@@ -364,7 +364,11 @@ def cms_profile(
         ppTransferFunction[2] = NULL
 
         if gamma is not None:
-            raise NotImplementedError  # TODO: implement gamma functions
+            if profile == 'gray':
+                pTransferFunction = cmsBuildGamma(<cmsContext> NULL, <cmsFloat64Number> gamma)
+            elif profile == 'rgb':
+                for i in range(3):
+                    ppTransferFunction[i] = cmsBuildGamma(<cmsContext> NULL, <cmsFloat64Number> gamma)
             # cmsBuildGamma(<cmsContext> NULL, gamma)
         elif transferfunction is not None:
             tf = numpy.ascontiguousarray(transferfunction)

--- a/imagecodecs/_cms.pyx
+++ b/imagecodecs/_cms.pyx
@@ -369,13 +369,13 @@ def cms_profile(
         elif transferfunction is not None:
             tf = numpy.ascontiguousarray(transferfunction)
             if tf.ndim == 1:
-                if tf.char == 'H':
+                if tf.dtype.char == 'H':
                     pTransferFunction = cmsBuildTabulatedToneCurve16(
                         <cmsContext> NULL,
                         <cmsUInt32Number> tf.shape[0],
                         <const cmsUInt16Number*> &tf.data[0]
                     )
-                elif tf.char == 'f':
+                elif tf.dtype.char == 'f':
                     pTransferFunction = cmsBuildTabulatedToneCurveFloat(
                         <cmsContext> NULL,
                         <cmsUInt32Number> tf.shape[0],
@@ -388,14 +388,14 @@ def cms_profile(
             elif tf.ndim == 2:
                 if tf.shape[0] != 3:
                     raise ValueError('invalid transferfunction shape')
-                if tf.char == 'H':
+                if tf.dtype.char == 'H':
                     for i in range(3):
                         ppTransferFunction[i] = cmsBuildTabulatedToneCurve16(
                             <cmsContext> NULL,
                             <cmsUInt32Number> tf.shape[1],
                             <const cmsUInt16Number*> &tf.data[i]
                         )
-                elif tf.char == 'f':
+                elif tf.dtype.char == 'f':
                     for i in range(3):
                         ppTransferFunction[i] = (
                             cmsBuildTabulatedToneCurveFloat(

--- a/imagecodecs/_cms.pyx
+++ b/imagecodecs/_cms.pyx
@@ -422,7 +422,7 @@ def cms_profile(
                         ppTransferFunction[i] = cmsBuildTabulatedToneCurve16(
                             <cmsContext> NULL,
                             <cmsUInt32Number> tf.shape[1],
-                            <const cmsUInt16Number*> &tf.data[i]
+                            <const cmsUInt16Number*> &tf.data[2*i*tf.shape[1]]
                         )
                 elif tf.dtype.char == 'f':
                     for i in range(3):
@@ -430,7 +430,7 @@ def cms_profile(
                             cmsBuildTabulatedToneCurveFloat(
                                 <cmsContext> NULL,
                                 <cmsUInt32Number> tf.shape[1],
-                                <const cmsFloat32Number*> &tf.data[i]
+                                <const cmsFloat32Number*> &tf.data[4*i*tf.shape[1]]
                             )
                         )
                 else:

--- a/imagecodecs/_cms.pyx
+++ b/imagecodecs/_cms.pyx
@@ -373,22 +373,47 @@ def cms_profile(
         elif transferfunction is not None:
             tf = numpy.ascontiguousarray(transferfunction)
             if tf.ndim == 1:
-                if tf.dtype.char == 'H':
-                    pTransferFunction = cmsBuildTabulatedToneCurve16(
-                        <cmsContext> NULL,
-                        <cmsUInt32Number> tf.shape[0],
-                        <const cmsUInt16Number*> &tf.data[0]
-                    )
-                elif tf.dtype.char == 'f':
-                    pTransferFunction = cmsBuildTabulatedToneCurveFloat(
-                        <cmsContext> NULL,
-                        <cmsUInt32Number> tf.shape[0],
-                        <const cmsFloat32Number*> &tf.data[0]
-                    )
-                else:
-                    raise ValueError('invalid transferfunction dtype')
-                if pTransferFunction == NULL:
-                    raise CmsError('cmsBuildTabulatedToneCurve returned NULL')
+                if profile == 'gray':
+                    if tf.dtype.char == 'H':
+                        pTransferFunction = cmsBuildTabulatedToneCurve16(
+                            <cmsContext> NULL,
+                            <cmsUInt32Number> tf.shape[0],
+                            <const cmsUInt16Number*> &tf.data[0]
+                        )
+                    elif tf.dtype.char == 'f':
+                        pTransferFunction = cmsBuildTabulatedToneCurveFloat(
+                            <cmsContext> NULL,
+                            <cmsUInt32Number> tf.shape[0],
+                            <const cmsFloat32Number*> &tf.data[0]
+                        )
+                    else:
+                        raise ValueError('invalid transferfunction dtype')
+                    if pTransferFunction == NULL:
+                        raise CmsError('cmsBuildTabulatedToneCurve returned NULL')
+                elif profile == 'rgb':
+                    if tf.dtype.char == 'H':
+                        for i in range(3):
+                            ppTransferFunction[i] = cmsBuildTabulatedToneCurve16(
+                                <cmsContext> NULL,
+                                <cmsUInt32Number> tf.shape[0],
+                                <const cmsUInt16Number*> &tf.data[0]
+                            )
+                    elif tf.dtype.char == 'f':
+                        for i in range(3):
+                            ppTransferFunction[i] = (
+                                cmsBuildTabulatedToneCurveFloat(
+                                    <cmsContext> NULL,
+                                    <cmsUInt32Number> tf.shape[0],
+                                    <const cmsFloat32Number*> &tf.data[0]
+                                )
+                            )
+                    else:
+                        raise ValueError('invalid transferfunction dtype')
+                    for i in range(3):
+                        if ppTransferFunction[i] == NULL:
+                            raise CmsError(
+                                'cmsBuildTabulatedToneCurve returned NULL'
+                            )
             elif tf.ndim == 2:
                 if tf.shape[0] != 3:
                     raise ValueError('invalid transferfunction shape')


### PR DESCRIPTION
Currently, if a single TRC is provided for an RGB profile, it fails silently at https://github.com/cgohlke/imagecodecs/blob/master/imagecodecs/_cms.pyx#L428

The first commit in this PR will copy a single TRC three times if it is provided for an RGB profile

The second commit fixes indexing into the array of shape (3,trcLen) for cases where the user has duplicated the TRC three times, or has three different TRCs

I can split this into separate PRs as desired