### PR TITLE
Fix indexing in updated CMS implementation

### DIFF
--- a/imagecodecs/_cms.pyx
+++ b/imagecodecs/_cms.pyx
@@ -392,8 +392,8 @@ def cms_profile(
                 if tf.dtype.char == 'H':
                     ppTransferFunction[i] = cmsBuildTabulatedToneCurve16(
                         <cmsContext> NULL,
-                        <cmsUInt32Number> tf.shape[0],
-                        <const cmsUInt16Number*> &tf.data[j]
+                        <cmsUInt32Number> tf.shape[tf.ndim-1],
+                        <const cmsUInt16Number*> &tf.data[j*2*tf.shape[tf.ndim-1]]
                     )
                     if ppTransferFunction[i] == NULL:
                         raise CmsError(
@@ -403,8 +403,8 @@ def cms_profile(
                     # tf.dtype.char == 'f'
                     ppTransferFunction[i] = cmsBuildTabulatedToneCurveFloat(
                         <cmsContext> NULL,
-                        <cmsUInt32Number> tf.shape[0],
-                        <const cmsFloat32Number*> &tf.data[j]
+                        <cmsUInt32Number> tf.shape[tf.ndim-1],
+                        <const cmsFloat32Number*> &tf.data[j*4*tf.shape[tf.ndim-1]]
                     )
                     if ppTransferFunction[i] == NULL:
                         raise CmsError(


### PR DESCRIPTION
The new implementation used tf.shape[0], which led to truncated TRCs if there were three independent TRCs since tf.shape[0] == 3 in that case

Use tf.shape[tf.ndims-1] instead.  tf.shape[-1] does not appear to function correctly, likely due to cython having somewhat different indexing than python?

Also, the indexing into tf.data remains in bytes, so the size of the data items must be taken into account, and each TRC starts at j*sizeof(dataitem)*tf.shape[tf.ndims-1] - not sure if there's a cython equivalent for sizeof()?