### PR TITLE
update deflate library name on conda-forge

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -503,7 +503,7 @@ def customize_build_condaforge(EXTENSIONS, OPTIONS):
                 os.environ['LIBRARY_INC'], 'openjpeg-' + os.environ['openjpeg']
             )
         ]
-        EXTENSIONS['deflate']['libraries'] = ['libdeflate']
+        EXTENSIONS['deflate']['libraries'] = ['deflate']
         EXTENSIONS['jpegls']['libraries'] = ['charls-2-x64']
         EXTENSIONS['lz4']['libraries'] = ['liblz4']
         EXTENSIONS['lzma']['libraries'] = ['liblzma']


### PR DESCRIPTION
deflate 1.16 and 1.17 changed the build system to cmake, so this changed the name of the library on windows on conda-forge