### PR TITLE
Enable APNG for MinGW

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -538,7 +538,6 @@ def customize_build_macports(EXTENSIONS, OPTIONS):
 def customize_build_mingw(EXTENSIONS, OPTIONS):
     """Customize build for mingw-w64."""
 
-    del EXTENSIONS['apng']
     del EXTENSIONS['brunsli']
     del EXTENSIONS['heif']
     del EXTENSIONS['jetraw']  # commercial


### PR DESCRIPTION
The MSYS2 libpng is patched: https://github.com/msys2/MINGW-packages/blob/814ac15808f7ee3cd5a7170a0ad34863a6a3e895/mingw-w64-libpng/PKGBUILD#L28