### PR TITLE
Enable libjpeg-turbo 3 for MinGW

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -547,8 +547,7 @@ def customize_build_mingw(EXTENSIONS, OPTIONS):
     del EXTENSIONS['zfp']
     del EXTENSIONS['zlibng']
 
-    # uncomment if building with libjpeg-turbo 3
-    # EXTENSIONS['jpeg8']['sources'] = []
+    EXTENSIONS['jpeg8']['sources'] = []  # use libjpeg-turbo 3
 
     EXTENSIONS['jpeg2k']['include_dirs'].extend(
         (


### PR DESCRIPTION
Now available in the MSYS2 repos: https://packages.msys2.org/base/mingw-w64-libjpeg-turbo