### PR TITLE
Add Cython flag to signal free-threading compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 # imagecodecs/pyproject.toml
 
 [build-system]
-requires = ["setuptools", "wheel", "numpy", "Cython>=3.0.11"]
+requires = ["setuptools", "wheel", "numpy", "Cython>=3.0.11", "packaging"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
These are the necessary changes for `imagecodecs` to signify that it's compatible with the Python 3.13 free-threaded build. I've run some tests and everything seems to be running fine with it, apart from the issue described in #112.