### PR TITLE
Update libultrahdr.pxd for 1.3.0

### DIFF
--- a/imagecodecs/libultrahdr.pxd
+++ b/imagecodecs/libultrahdr.pxd
@@ -1,7 +1,7 @@
 # imagecodecs/libultrahdr.pxd
 # cython: language_level = 3
 
-# Cython declarations for the `libultrahdr 1.2.0` library.
+# Cython declarations for the `libultrahdr 1.3.0` library.
 # https://github.com/google/libultrahdr
 
 cdef extern from 'ultrahdr_api.h' nogil:
@@ -99,16 +99,16 @@ cdef extern from 'ultrahdr_api.h' nogil:
 
     ctypedef struct uhdr_compressed_image_t:
         void* data
-        unsigned int data_sz
-        unsigned int capacity
+        size_t data_sz
+        size_t capacity
         uhdr_color_gamut_t cg
         uhdr_color_transfer_t ct
         uhdr_color_range_t range
 
     ctypedef struct uhdr_mem_block_t:
         void* data
-        unsigned int data_sz
-        unsigned int capacity
+        size_t data_sz
+        size_t capacity
 
     ctypedef struct uhdr_gainmap_metadata_t:
         float max_content_boost


### PR DESCRIPTION
Edit: There is also a new `uhdr_enc_set_target_display_peak_brightness` method I forgot to add:

https://github.com/google/libultrahdr/compare/v1.2.0...v1.3.0#diff-e951411c55e1deb1a7de8facfd83c49ec55f9f02953c91cf41c300700cf3f30c