### PR TITLE
Enable htj2k and meshopt for MinGW

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -694,13 +694,11 @@ def customize_build_mingw(
     for ext in (
         'brunsli',
         'heif',
-        'htj2k',
         'jetraw',
         'jpegxs',
         'lzfse',
         'lzham',
         'lzo',
-        'meshopt',
         'mozjpeg',
         'openzl',
         'pcodec',


### PR DESCRIPTION
MSYS2 packages for openjph and meshoptimizer are available.