### PR TITLE
Add primaries and transfer_function parameters to jpegxl_encode

### DIFF
--- a/imagecodecs/_jpegxl.pyx
+++ b/imagecodecs/_jpegxl.pyx
@@ -143,6 +143,8 @@ def jpegxl_encode(
     planar=None,
     usecontainer=None,
     numthreads=None,
+    primaries=None,
+    transfer_function=None,
     out=None,
 ):
     """Return JPEGXL encoded image.
@@ -151,6 +153,15 @@ def jpegxl_encode(
 
     Currently, L, LA, RGB, and RGBA images are supported in contig mode.
     Extra channels are only supported for grayscale images in planar mode.
+
+    Parameters
+    ----------
+    primaries : int, optional
+        Color primaries enum value. Common values:
+        1 (sRGB, default), 9 (BT.2100), 11 (Display P3).
+    transfer_function : int, optional
+        Transfer function enum value. Common values:
+        1 (BT.709), 8 (linear), 13 (sRGB, default), 16 (PQ), 18 (HLG).
 
     """
     cdef:
@@ -187,6 +198,9 @@ def jpegxl_encode(
         int option_effort = _default_value(effort, 5, 1, 10)  # 7 is too slow
         float option_distance = _default_value(distance, 1.0, 0.0, 25.0)
         size_t num_threads = _default_threads(numthreads)
+        bint has_custom_color = primaries is not None or transfer_function is not None
+        int option_primaries = int(primaries) if primaries is not None else 0
+        int option_transfer = int(transfer_function) if transfer_function is not None else 0
         size_t channel_index
         uint32_t bits_per_sample
         bint is_planar = bool(planar)
@@ -403,8 +417,27 @@ def jpegxl_encode(
             if status != JXL_ENC_SUCCESS:
                 raise JpegxlError('JxlEncoderSetBasicInfo', status)
 
-            # TODO: review this
-            if pixel_format.data_type == JXL_TYPE_UINT8:
+            if has_custom_color:
+                color_encoding.color_space = <JxlColorSpace> colorspace
+                color_encoding.white_point = JXL_WHITE_POINT_D65
+                color_encoding.primaries = (
+                    <JxlPrimaries> option_primaries
+                    if option_primaries != 0
+                    else JXL_PRIMARIES_SRGB
+                )
+                color_encoding.transfer_function = (
+                    <JxlTransferFunction> option_transfer
+                    if option_transfer != 0
+                    else (
+                        JXL_TRANSFER_FUNCTION_SRGB
+                        if pixel_format.data_type == JXL_TYPE_UINT8
+                        else JXL_TRANSFER_FUNCTION_LINEAR
+                    )
+                )
+                color_encoding.rendering_intent = (
+                    JXL_RENDERING_INTENT_RELATIVE
+                )
+            elif pixel_format.data_type == JXL_TYPE_UINT8:
                 JxlColorEncodingSetToSRGB(
                     &color_encoding, colorspace == JXL_COLOR_SPACE_GRAY
                 )


### PR DESCRIPTION
`jpegxl_encode` currently hardcodes the color encoding to sRGB via `JxlColorEncodingSetToSRGB`. This PR adds optional `primaries` and `transfer_function` parameters that, when provided, manually populate the `JxlColorEncoding` struct to support standard color spaces like Display P3, BT.2020, etc.

This follows the same pattern as the `primaries`/`transfer`/`matrix` parameters added to `avif_encode` in v2025.11.11 (#131).

## Changes

- Add `primaries` and `transfer_function` keyword arguments to `jpegxl_encode`
- When either is set, populate `JxlColorEncoding` fields directly instead of calling `JxlColorEncodingSetToSRGB`
- When neither is set, behavior is unchanged (backward compatible)
- Python parameters are resolved to C ints before the `nogil` block

## Usage

```python
# Display P3 (sRGB gamma, wider primaries)
imagecodecs.jpegxl_encode(rgb, lossless=True, primaries=11, transfer_function=13)

# BT.2020
imagecodecs.jpegxl_encode(rgb, lossless=True, primaries=9)

# Default sRGB (unchanged)
imagecodecs.jpegxl_encode(rgb, lossless=True)
```

## Enum values (from libjxl)

**Primaries:** 1=sRGB, 9=BT.2100, 11=Display P3
**Transfer function:** 1=BT.709, 8=Linear, 13=sRGB, 16=PQ, 18=HLG

## Testing

Verified lossless round-trip on Linux x86_64 (Python 3.12, libjxl 0.11.1) for:
- uint8 RGB with sRGB (default), Display P3, BT.2020
- float32 RGB with P3 + linear transfer function
- uint8 grayscale with P3 primaries

## Use case

Display P3 is the native color space of Apple and many modern displays. For scientific imaging (fluorescence microscopy), encoding spectral data into Display P3 uses the wider gamut for more accurate color representation. The only current workaround is shelling out to `cjxl -x color_space=DisplayP3`.

Note: this is distinct from #130 (decoder-side XYB output) — this is encoder-side only and uses the existing `JxlEncoderSetColorEncoding` API with different enum values.
